### PR TITLE
[Issue#83] 修改綠界付款失敗與成功頁面

### DIFF
--- a/carts/urls.py
+++ b/carts/urls.py
@@ -10,6 +10,5 @@ urlpatterns = [
     path("delete/",views.delete,name='delete'),
     path("deleteAll/",views.delete_all,name='delete_all'),
     path("update/",views.update,name='update'),
-    path("confirm", views.confirm, name="confirm"),
-    path("payment", views.payment, name="payment"),
+    path("rebuyonfail/<int:order_id>/", views.rebuyonfail, name="rebuyonfail"),
 ]

--- a/carts/views.py
+++ b/carts/views.py
@@ -1,17 +1,9 @@
-from django.shortcuts import render, get_object_or_404
+from django.shortcuts import render, get_object_or_404, redirect
 from .cart import Cart
 from products.models import Product
 from django.http import JsonResponse
 from django.views.decorators.http import require_POST
-
-
-def confirm(request):
-    return render(request, "cart/cart_confirm.html")
-
-
-def payment(request):
-    return render(request, "cart/cart_payment.html")
-
+from orders.models import Order
 
 def summary(request):
     cart = Cart(request)
@@ -78,3 +70,14 @@ def delete_all(request):
 
         # 在成功刪除商品後，返回 JSON 響應
         return JsonResponse({"message": "Products deleted successfully."})
+
+
+def rebuyonfail(request, order_id):
+    cart = Cart(request)
+    order = Order.objects.get(order_id=order_id)
+    
+    for item in order.orderitem_set.all():
+        cart.add(item.product, item.quantity,)
+
+    return redirect('carts:summary')  
+

--- a/orders/views.py
+++ b/orders/views.py
@@ -234,7 +234,7 @@ def order_result(request):
             order.status = "waiting_for_shipment"
             order.save()
             return render(request, 'orders/order_success.html',{"order":order})
-        return render(request, 'orders/order_fail.html', {"order": order})
+        return render(request, 'orders/order_fail.html',{"rtncode":rtncode})
     else:
         return HttpResponse("Invalid request method", status=405)
 

--- a/orders/views.py
+++ b/orders/views.py
@@ -205,8 +205,6 @@ class ReturnView(View):
             HashKey=env("ECPAY_HASH_KEY"),
             HashIV=env("ECPAY_HASH_IV"),
         )
-        print("=" * 100)
-        print(request.body)
         res = request.POST.dict()
         back_check_mac_value = request.POST.get("CheckMacValue")
         check_mac_value = ecpay_payment_sdk.generate_check_value(res)
@@ -234,7 +232,7 @@ def order_result(request):
             order.status = "waiting_for_shipment"
             order.save()
             return render(request, 'orders/order_success.html',{"order":order})
-        return render(request, 'orders/order_fail.html',{"rtncode":rtncode})
+        return render(request, 'orders/order_fail.html', {"rtncode": rtncode, "order_id": order_id})
     else:
         return HttpResponse("Invalid request method", status=405)
 

--- a/orders/views.py
+++ b/orders/views.py
@@ -229,17 +229,12 @@ def order_result(request):
         rtnmsg = request.POST.get("RtnMsg")
         rtncode = request.POST.get("RtnCode")
         check_mac_value = ecpay_payment_sdk.generate_check_value(res)
-
-        if (
-            check_mac_value == back_check_mac_value
-            and rtnmsg == "Succeeded"
-            and rtncode == "1"
-        ):
+        if check_mac_value == back_check_mac_value and rtnmsg == 'Succeeded' and rtncode == '1':
             order = Order.objects.get(order_id=order_id)
             order.status = "waiting_for_shipment"
             order.save()
-            return render(request, "orders/order_success.html")
-        return render(request, "orders/order_fail.html")
+            return render(request, 'orders/order_success.html',{"order":order})
+        return render(request, 'orders/order_fail.html', {"order": order})
     else:
         return HttpResponse("Invalid request method", status=405)
 

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -6,7 +6,7 @@
 <div class="bg-gray-100 flex justify-center items-center h-screen">
   <div class="max-w-md w-full bg-white p-8 shadow-md rounded-md">
     {% if user.is_authenticated %}
-    <h2 class="text-2xl font-bold text-red-600">請先登出再執行登入</h2>
+      <h2 class="text-2xl font-bold text-red-600">請先登出再執行登入</h2>
     {% else %}
     <h2 class="text-2xl font-bold mb-6">登入</h2>
     <form method="POST" class="space-y-4">

--- a/templates/accounts/user.html
+++ b/templates/accounts/user.html
@@ -1,17 +1,17 @@
 {% extends 'shared/base.html' %}
 
 {% block content %}
-<div class="m-auto w-screen max-w-screen-xl shadow-lg" style="margin-top: 85px">
-  <div x-data="{ tab: 'user-info' }">
-    <nav class="bg-red-300 rounded-tl-xl rounded-tr-xl">
-      <div class="mx-auto px-4 sm:px-6 lg:px-8 shadow">
-        <div class="flex h-16 items-center justify-between">
-          <div class="flex items-center">
-            <div class="ml-10 flex items-baseline space-x-4">
-              <a href="#" @click.prevent="tab ='user-info'"
-                :class="{ 'bg-red-200 text-black rounded-md px-3 py-2 text-sm font-medium': tab === 'user-info', 'text-red-800 hover:bg-red-200 hover:text-white rounded-md px-3 py-2 text-sm font-medium': tab !== 'user-info' }">
-                個人資訊
-              </a>
+  <div class="m-auto w-screen max-w-screen-xl shadow-lg mt-20">
+    <div x-data="{ tab: 'user-info' }">
+      <nav class="bg-red-300 rounded-tl-xl rounded-tr-xl">
+        <div class="mx-auto px-4 sm:px-6 lg:px-8 shadow">
+          <div class="flex h-16 items-center justify-between">
+            <div class="flex items-center">
+              <div class="ml-10 flex items-baseline space-x-4">
+                <a href="#" @click.prevent="tab ='user-info'"
+                  :class="{ 'bg-red-200 text-black rounded-md px-3 py-2 text-sm font-medium': tab === 'user-info', 'text-red-800 hover:bg-red-200 hover:text-white rounded-md px-3 py-2 text-sm font-medium': tab !== 'user-info' }">
+                  個人資訊
+                </a>
 
               <a href="#" id="user-coupon" @click="tab='user-coupon'" class="text-red-800 hover:bg-red-200 hover:text-white rounded-md px-3 py-2 text-sm font-medium" :class="{ 'bg-red-200 text-black': tab === 'user-coupon', 'text-red-800': tab !== 'user-coupon' }">
                 優惠券
@@ -37,29 +37,28 @@
 		{% include "accounts/user_favorite.html" %}
 		{% include "accounts/user_orderlist.html" %}
   </div>
-</div>
-<script>
-  $(document).on('click', '.delete-favorite-btn', function (e){
-    e.preventDefault();
-    card = this.closest('.card')
-    product_id = $(this).data('index')
-  
-    $.ajax({
-      type: 'POST',
-      url: "{% url 'accounts:favorite-delete' %}",
-      data: {
-        product_id: $(this).data('index'),
-        csrfmiddlewaretoken: '{{ csrf_token }}',
-        action: 'post'
-      },
-      success: function (json){
-        card.remove()       
-      },
-      error: function (xhr, errmsg, err){
-      }
+  <script>
+    $(document).on('click', '.delete-favorite-btn', function (e){
+      e.preventDefault();
+      card = this.closest('.card')
+      product_id = $(this).data('index')
+    
+      $.ajax({
+        type: 'POST',
+        url: "{% url 'accounts:favorite-delete' %}",
+        data: {
+          product_id: $(this).data('index'),
+          csrfmiddlewaretoken: '{{ csrf_token }}',
+          action: 'post'
+        },
+        success: function (json){
+          card.remove()       
+        },
+          error: function (xhr, errmsg, err){
+        }
+      })
     })
-  })
 
-</script>
+  </script>
 
 {% endblock %}

--- a/templates/orders/order_fail.html
+++ b/templates/orders/order_fail.html
@@ -1,20 +1,20 @@
 {% extends "shared/base.html" %}
 {% load static %}
-
-
 {% block content %}
-<!-- Page Wrapper -->
-<section class="page-wrapper success-msg">
-  <div class="container mt-28">
-    <div class="row">
-      <div class="col-md-6 col-md-offset-3">
-        <div class="block text-center">
-          <i class="tf-ion-android-checkmark-circle"></i>
-          <h2 class="text-center">付款失敗，請重新下單</h2>
-          <a href="{% url 'home' %}" class="btn btn-main mt-20">Continue Shopping</a>
-        </div>
+
+<section class="page-wrapper fail-msg">
+  <div class="container mt-28 mx-auto">
+    <div class="col-md-6 col-md-offset-3">
+      <div class="block text-center">
+        <h2 class="text-center text-4xl font-bold mb-6">付款失敗，請重新下單</h2>
+        {% if rtncode == '10100058' %}
+          <p> 您好, 支付系統因預期外的原因發生錯誤, 請使用另一張信用卡重新下單, 若持續失敗請由'使用者資訊'的'訊息'與我們聯繫處理
+          </p>
+        {% else %}
+          <p>您好, 支付系統因預期外的原因發生錯誤, 請由'使用者資訊'的'訊息'與我們聯繫處理</p>
+        {% endif %}
       </div>
     </div>
   </div>
-</section><!-- /.page-warpper -->
+</section>
 {% endblock content %}

--- a/templates/orders/order_fail.html
+++ b/templates/orders/order_fail.html
@@ -2,18 +2,23 @@
 {% load static %}
 {% block content %}
 
-<section class="page-wrapper fail-msg">
+<section class="fail-msg">
   <div class="container mt-28 mx-auto">
-    <div class="col-md-6 col-md-offset-3">
-      <div class="block text-center">
-        <h2 class="text-center text-4xl font-bold mb-6">付款失敗，請重新下單</h2>
+    <div class="block text-center">
+      <h2 class="text-center text-4xl font-bold mb-6">付款失敗，請重新下單</h2>
         {% if rtncode == '10100058' %}
           <p> 您好, 支付系統因預期外的原因發生錯誤, 請使用另一張信用卡重新下單, 若持續失敗請由'使用者資訊'的'訊息'與我們聯繫處理
           </p>
         {% else %}
           <p>您好, 支付系統因預期外的原因發生錯誤, 請由'使用者資訊'的'訊息'與我們聯繫處理</p>
         {% endif %}
-      </div>
+    </div>
+    <div class="mx-auto flex justify-center">
+      <form method="post" action="{% url 'carts:rebuyonfail' order_id=order_id %}">
+        {% csrf_token %}
+        <input type="hidden" name="order_id" value="{{ order_id }}">
+        <button type="submit" class="rounded-xl mt-10 p-2 bg-red-300 hover:bg-red-500">重新購買</button>
+      </form>
     </div>
   </div>
 </section>

--- a/templates/orders/order_form.html
+++ b/templates/orders/order_form.html
@@ -151,7 +151,7 @@
               <h3>收件人資訊</h3>
             </div>
             <div class="flex items-center">
-              <input type="checkbox" x-model="useOrderInfo" x-on:change="syncInfo()" id="sameAsOrderInfo" class="form-checkbox h-5 w-5 text-red-600">
+              <input type="checkbox" x-model="useOrderInfo" x-on:change="syncInfo" id="sameAsOrderInfo" class="form-checkbox h-5 w-5 text-red-600">
               <label for="sameAsOrderInfo" class="text-gray-700 ml-2 cursor-pointer">同訂購人資訊</label>
             </div>
           </div>

--- a/templates/orders/order_success.html
+++ b/templates/orders/order_success.html
@@ -1,16 +1,84 @@
 {% extends "shared/base.html" %}
 {% load static %}
-
+{% load humanize %}
 {% block content %}
 
-<section class="page-wrapper success-msg">
-  <div class="container mt-28">
-    <div class="row">
-      <div class="col-md-6 col-md-offset-3">
-        <div class="block text-center">
-          <i class="tf-ion-android-checkmark-circle"></i>
-          <h2 class="text-center">付款成功</h2>
-          <a href="{% url 'home'%}" class="btn btn-main mt-20">Continue Shopping</a>
+<section class="success-msg">
+  <div class="container mt-28 mx-auto">
+    <h2 class="text-center text-4xl font-bold mb-6">付款成功</h2>
+    <div class="mx-auto mb-4 w-screen max-w-screen-xl text-center sm:mt-0  sm:text-left">
+      <h3 class="text-lg leading-6 font-medium text-gray-900" id="order-detail-title">
+        以下為此次訂單編號：{{ order.order_id }} 的購買明細：
+      </h3>
+      <div class="flex mt-2 p-2 bg-red-200 text-xl font-semibold rounded-xl shadow-lg">
+        <div class="w-6/12 p-2">
+          <p>商品明細</p>
+        </div>
+        <div class="w-3/12 p-2 border-l-2 border-red-400">
+          <p>類別</p>
+        </div>
+        <div class="w-1/12 p-2 border-l-2 border-red-400">
+          <p>單價</p>
+        </div>
+        <div class="w-1/12 p-2 border-l-2 border-red-400">
+          <p>數量</p>
+        </div>
+        <div class="w-1/12 p-2 border-l-2 border-red-400">
+          <p>總價</p>
+        </div>
+      </div>
+      <!-- order list -->
+      <div class="order-list shadow-lg">
+        {% for item in order.orderitem_set.all %}
+        <div class="flex mt-2 p-2 h-52 rounded-xl text-xl border-2 border-red-300 cake" data-product-id="{{ item.product.id }}">
+          <div class="flex w-6/12 p-2">
+            <div class="product-img rounded-2xl w-[180px] h-[180px] overflow-hidden">
+              <img src="{{ item.product.image.url }}" alt="#" class="w-full h-full object-cover">
+            </div>
+            <div class="flex flex-col m-auto w-1/2 p-2">
+              <p>{{ item.product.name }}</p>
+            </div>
+          </div>
+          <div class="flex flex-col m-auto w-3/12 p-2">
+            <p>{{ item.product.category.name }}</p>
+          </div>
+          <div class="flex flex-col m-auto w-1/12 p-2">
+            <p>${{ item.price }}</p>
+          </div>
+          <div class="flex flex-col m-auto w-1/12 p-2">
+            <p>{{ item.quantity }}</p>
+          </div>
+          <div class="flex flex-col m-auto w-1/12 p-2">
+            <p>$ {{ item.item_total }}</p>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+      <!-- detail list -->
+      <div class="mt-2">
+        <div class="flex justify-center">
+          <div class="bg-white shadow-lg rounded-lg overflow-hidden w-full">
+            <div class="md:flex">
+                <!-- 收件信息 -->
+              <div class="md:w-1/2 p-5">
+                <h3 class="text-lg font-semibold text-gray-700">收件資訊</h3>
+                <p class="mt-2 text-gray-600"><strong>購買人:</strong> {{ order.ordermethod.order_name }}</p>
+                <p class="mt-2 text-gray-600"><strong>電郵:</strong> {{ order.email }}</p>
+                <p class="mt-2 text-gray-600"><strong>電話:</strong> {{ order.phone }}</p>
+                <p class="mt-2 text-gray-600"><strong>收件人姓名:</strong> {{ order.name }}</p>
+                <p class="mt-2 text-gray-600"><strong>收件人電話:</strong> {{ order.phone }}</p>
+                <p class="mt-2 text-gray-600"><strong>收件人電郵:</strong> {{ order.email }}</p>
+                <p class="mt-2 text-gray-600"><strong>收件地址:</strong> {{ order.address }}</p>
+              </div>
+              <!-- 購買信息 -->
+              <div class="md:w-1/2 p-5 border-l-2 border-gray-200">
+                <h3 class="text-lg font-semibold text-gray-700">購買資訊</h3>
+                <p class="mt-2 text-gray-600"><strong>總金額:</strong> ${{ order.total|intcomma }}</p>
+                <p class="mt-2 text-gray-600"><strong>訂單成立時間:</strong> {{ order.created|date:"Y-m-d H:i" }}</p>
+                <p class="mt-2 text-gray-600"><strong>目前訂單狀態:</strong> {{ order.get_status_display }}</p>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
<img width="1708" alt="截圖 2024-06-07 凌晨3 24 56" src="https://github.com/astrocamp/16th-CakeCapture/assets/138242581/7fcb3520-ed25-4db2-b2c9-085c78fb3c09">
<img width="1710" alt="截圖 2024-06-07 凌晨1 02 45" src="https://github.com/astrocamp/16th-CakeCapture/assets/138242581/f1ce779e-20ee-4160-b248-f2c5b1e3e5cf">

修正 成功與失敗畫面

成功會帶入 訂單資訊

失敗則會提示重新下單, 並提供原訂單重新放入購物車的按鈕, 點擊後會跳轉至購物車, 並將原訂單的物品放入購物車