### PR TITLE
[Issue#161] 修復結帳時不選擇優惠券，會報錯問題

### DIFF
--- a/orders/forms.py
+++ b/orders/forms.py
@@ -5,7 +5,7 @@ from accounts.models import UserCoupon
 
 class OrderForm(forms.ModelForm):
 
-    used_coupon = forms.ChoiceField()
+    used_coupon = forms.ChoiceField(required=False)
 
     def __init__(self, *args, **kwargs):
         user = kwargs["initial"]["user"]
@@ -70,8 +70,6 @@ class OrderForm(forms.ModelForm):
             }
         )
     )
-
-    # coupon_code = forms.CharField(max_length=20, required=False, label="優惠券代碼")
 
     class Meta:
         model = OrderMethod

--- a/orders/views.py
+++ b/orders/views.py
@@ -333,14 +333,17 @@ def line_pay_request(request):
     if request.method == "POST":
         order_id = request.POST.get("order_id")
         order = Order.objects.get(order_id=order_id)
+        
 
-        used_coupon_id = order.used_coupon.id
-        user_coupon = UserCoupon.objects.get(pk=used_coupon_id)
+        if order.used_coupon:
+            used_coupon_id = order.used_coupon.id
+            user_coupon = UserCoupon.objects.get(pk=used_coupon_id)
+            user_coupon.order = order
+            user_coupon.used_at = datetime.now()
+            user_coupon.usage_count = user_coupon.usage_count + 1
+            user_coupon.save()
 
-        user_coupon.order = order
-        user_coupon.used_at = datetime.now()
-        user_coupon.usage_count = user_coupon.usage_count + 1
-        user_coupon.save()
+    
         order.confirm()
 
         package_id = order.pk

--- a/orders/views.py
+++ b/orders/views.py
@@ -122,13 +122,14 @@ def order_confirm(request):
                 shipping_fee = 70
             
             if used_coupon_id:
+                code = UserCoupon.objects.get(pk=used_coupon_id)
                 if (
-                    Coupon.objects.get(code=order.used_coupon).discount
+                    Coupon.objects.get(code=code).discount
                     > totals + shipping_fee
                 ):
                     coupon_discount = totals + shipping_fee
                 else:
-                    coupon_discount = Coupon.objects.get(code=order.used_coupon).discount
+                    coupon_discount = Coupon.objects.get(code=code).discount
             else:
                 coupon_discount = 0
 


### PR DESCRIPTION
1. 在結帳頁若不選擇任何 coupon，將不會影響結帳流程，且折扣金額為 0。